### PR TITLE
drop 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,11 +159,6 @@ jobs:
             runs-on: macos-latest
             matrix: macos
         python:
-          - name: 3.6
-            tox: py36
-            action: 3.6
-            docker: 3.6
-            matrix: cpython3.6
           - name: 3.7
             tox: py37
             action: 3.7

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,14 @@
-qts 0.3
+qts [unreleased]
 ================
+
+Removals
+--------
+
+- Dropped testing of and support for EOL Python 3.6.
+
+
+qts 0.3
+=======
 
 Features
 --------

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ classifiers =
         Topic :: Software Development :: User Interfaces
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     # >= 20.1.0 for attr.frozen
     attrs >= 20.1.0


### PR DESCRIPTION
There was some issue with PyQt6 on Windows with Python 3.6.  Just trying to enhance maintainabilty here so it doesn't get entirely stuck.